### PR TITLE
Readme: package is called npm-lint

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# npm-linter
+# npm-lint
 A opinionated, but configurable linter for npm &amp; node package.json files with a focus on security.
 
 [Github](https://github.com/tanepiper/npm-lint) | [Issues](https://github.com/tanepiper/npm-lint/issues) | [NPM](https://www.npmjs.com/package/npm-lint)


### PR DESCRIPTION
Having an header `npm-linter` might mislead the reader about the
actual name of the package.